### PR TITLE
Modifed the description of parasoftToolOrJavaRootPath

### DIFF
--- a/PublishParasoftResults/task.json
+++ b/PublishParasoftResults/task.json
@@ -50,7 +50,7 @@
             "label": "Root path to Parasoft tool/Java installation",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Absolute location of the root path of a Parasoft tool or a standalone Java installation (Parasoft tools contain a Java installation). When found at the specified location, Java is used to optimize the efficiency of report processing. If not specified or found, report processing will be much slower."
+            "helpMarkDown": "Absolute location of the root path of a Parasoft tool (Jtest, dotTest, or C/C++test that includes a Java installation) or a standalone Java installation. When found at the specified location, Java optimizes the efficiency of report processing. Otherwise, report processing will be significantly slower and may encounter memory issues when handling large reports."
         },
         {
             "name": "localSettingsPath",


### PR DESCRIPTION
The documentation should be modfied:

**Item 5 in Configuring the Extension section**

5.(Optional but strongly recommended) Configure the Root path to Parasoft tool/Java installation field. You can enter the absolute location of the root path of a Parasoft tool (Jtest, dotTEST or C/C++test contains a Java installation) or a standalone Java installation to significantly optimize the efficiency of report processing. This is particularly effective for large projects and can avoid memory issues.


**Add FAQs and Troubleshooting section**

**How can I fix the "JavaScript heap out of memory" issue when Parasfot Findings processes reports?**
The screenshot of this issus is like
![image](https://github.com/parasoft/parasoft-findings-vsts/assets/109122571/0c1a95c8-ca39-48e3-89b9-d1a065636216)

This issue may happen when Parasoft Finsings processes large reports. Configure the "Root path to Parasoft tool/Java installation" field to use Java to process large reports instead of JavaScript. You can check debug logs to see if Java is used to process report or not.	

**How can I fix the "JAXP00010004" Error when I use Java to process large reports?**
The screenshot of this issus is like
![image](https://github.com/parasoft/parasoft-findings-vsts/assets/109122571/d495d4fb-a9fe-4dd8-a4bf-6374505f457f)
This issue may happen when Parasoft Finsings processes large reports after the "Root path to Parasoft tool/Java installation" field is setted. It is a the [limitation of JAXP](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jaxp/jaxp.html#jaxp-properties-for-processing-limits), please refer to [Using the jaxp.properties File](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jaxp/jaxp.html#using-the-jaxp-properties-file) section to change the value of jdk.xml.totalEntitySizeLimit proerty to a large value. Or add a system environment variable JAVA_TOOL_OPTIONS=-Djdk.xml.totalEntitySizeLimit={aBigNumber}, e.g JAVA_TOOL_OPTIONS=-Djdk.xml.totalEntitySizeLimit=2147480000.