### PR TITLE
An exception occurs when the Reference Pipeline task is run only once

### DIFF
--- a/PublishParasoftResults/BuildApiClient.ts
+++ b/PublishParasoftResults/BuildApiClient.ts
@@ -89,7 +89,8 @@ export class BuildAPIClient {
         builds: Build[],
         projectName: string,
         artifactName: string,
-        fileSuffix: FileSuffixEnum
+        fileSuffix: FileSuffixEnum,
+        currentBuildId: string
         ): Promise<DefaultBuildReportResults> {
 
         let defaultBuildReportResults: DefaultBuildReportResults = {
@@ -100,7 +101,7 @@ export class BuildAPIClient {
         }
 
         let fileEntries: FileEntry[] = [];
-        if (builds.length == 1) { // only include current build
+        if (builds.length == 1 && builds[0].id?.toString() == currentBuildId) { // only include current build
             defaultBuildReportResults.status = DefaultBuildReportResultsStatus.NO_PREVIOUS_BUILD_WAS_FOUND;
             return Promise.resolve(defaultBuildReportResults);
         }

--- a/PublishParasoftResults/ParaReportPublishService.ts
+++ b/PublishParasoftResults/ParaReportPublishService.ts
@@ -123,6 +123,7 @@ export class ParaReportPublishService {
     projectName: string;
     pipelineName: string;
     buildNumber: string;
+    buildId: string;
     definitionId: number;
     defaultWorkingDirectory: string;
     inputReportFiles: string[];
@@ -157,6 +158,7 @@ export class ParaReportPublishService {
         this.buildClient = new BuildAPIClient();
         this.projectName = tl.getVariable('System.TeamProject') || '';
         this.buildNumber = tl.getVariable('Build.BuildNumber') || '';
+        this.buildId = tl.getVariable('Build.BuildId') || '';
         this.pipelineName = tl.getVariable('Build.DefinitionName') || '';
         this.definitionId = Number(tl.getVariable('System.DefinitionId'));
 
@@ -985,7 +987,7 @@ export class ParaReportPublishService {
         const allBuildsForSpecificPipeline = await this.buildClient.getBuildsForSpecificPipeline(this.projectName, specificReferencePipelineId);
         if (!this.referenceBuild) { // Reference build is not specified
             tl.debug(`No reference build has been set; using the last successful build in pipeline '${pipelineName}' as reference.`);
-            let defaultBuildReportResults: DefaultBuildReportResults = await this.buildClient.getDefaultBuildReports(allBuildsForSpecificPipeline, this.projectName, this.SARIF_ARTIFACT_NAME, FileSuffixEnum.SARIF_SUFFIX);
+            let defaultBuildReportResults: DefaultBuildReportResults = await this.buildClient.getDefaultBuildReports(allBuildsForSpecificPipeline, this.projectName, this.SARIF_ARTIFACT_NAME, FileSuffixEnum.SARIF_SUFFIX, this.buildId);
             switch (defaultBuildReportResults.status) {
                 case DefaultBuildReportResultsStatus.OK:
                     referenceBuildInfo.fileEntries = defaultBuildReportResults.reports || [];


### PR DESCRIPTION
Determine whether the reference build is the current build when there is only one build