### PR TITLE
Fix bug when the reference pipline name is not set and reference build number is set to the current build number

### DIFF
--- a/CodeCoverageQualityGate/CodeCoverageQualityService.ts
+++ b/CodeCoverageQualityGate/CodeCoverageQualityService.ts
@@ -242,7 +242,7 @@ export class CodeCoverageQualityService {
             warningMessage: undefined,
             isDebugMessage: false
         };
-        if (this.originalReferencePipelineName == this.pipelineName && this.originalReferenceBuildNumber == this.buildNumber) {
+        if ((!this.originalReferencePipelineName || this.originalReferencePipelineName == this.pipelineName) && this.originalReferenceBuildNumber == this.buildNumber) {
             referenceBuildInfo.warningMessage = "the current build is not allowed to use as the reference";
         } else {
             if (!this.originalReferencePipelineName) { // Reference pipeline is not specified

--- a/PublishParasoftResults/ParaReportPublishService.ts
+++ b/PublishParasoftResults/ParaReportPublishService.ts
@@ -886,7 +886,7 @@ export class ParaReportPublishService {
             },
             isDebugMessage: false
         };
-        if (this.referencePipeline == this.pipelineName && this.referenceBuild == this.buildNumber) {
+        if ((!this.referencePipeline || this.referencePipeline == this.pipelineName) && this.referenceBuild == this.buildNumber) {
             referenceBuildInfo.staticAnalysis.warningMessage = 'Using the current build as the reference';
         } else {
             if (!this.referencePipeline) { // Reference pipeline is not specified


### PR DESCRIPTION
For static analysis quality gate, the warning message is "**Using the current build as the reference - all issues will be treated as new**".

For code coverage quality gate, the warning message is "**Quality gate 'Type: xx, Threshold: xx, Reference build: xx' skipped; the current build is not allowed to use as the reference**".